### PR TITLE
2 | Templatize Python Pipeline

### DIFF
--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -1,10 +1,7 @@
 name: CI/CD Pipeline
 
 on:
-  pull_request:
-    branches: [ master ]
-  push:
-    branches: [ master ]
+  workflow_call:
 
 env:
   IMAGE_NAME: python-hello-service

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -2,9 +2,16 @@ name: CI/CD Pipeline
 
 on:
   workflow_call:
-
-env:
-  IMAGE_NAME: python-hello-service
+    inputs:
+      image-name:
+        description: 'Docker image name'
+        required: true
+        type: string
+      python-version:
+        description: 'Python version to use'
+        required: false
+        type: string
+        default: '3.13'
 
 jobs:
   docker-build:
@@ -15,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Docker Image
-        run: docker build -t $IMAGE_NAME:${{ github.sha }} .
+        run: docker build -t ${{ inputs.image-name }}:${{ github.sha }} .
 
   tests:
     name: Run Unit Tests
@@ -28,7 +35,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Dependencies
         run: |
@@ -59,7 +66,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Dependencies
         run: |
@@ -92,7 +99,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
### Summary
- Removing the `pull_request` and `push` rule and replacing with `on: workflow_call: ` so it can be treated as a template and doesn't run in this repo

### Testing
- [x] [python pipeline](https://github.com/jlmOrg/python-microservice/pull/15) can run without issues using this ci-cd

Closes #2 