### PR TITLE
7 | ECR Connectivity

### DIFF
--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -150,7 +150,7 @@ jobs:
         run: docker load < ${{ inputs.image-name }}.tar
 
       - name: Tag Image
-        run: docker tag $IMAGE_TAG $ECR_REGISTRY/${{ inputs.image-name }}:${{ github.sha }}
+        run: docker tag $IMAGE_TAG ${{ inputs.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
 
       - name: Configure AWS Creds
         uses: aws-actions/configure-aws-credentials@v4
@@ -163,4 +163,4 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Push image to ECR
-        run: docker push $ECR_REGISTRY/${{ inputs.image-name }}:${{ github.sha }}
+        run: docker push ${{ inputs.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -29,7 +29,7 @@ jobs:
         run: docker build -t ${{ inputs.image-name }}:${{ github.sha }} .
 
       - name: Save Image
-        run: docker save $IMAGE_TAG > ${{ inputs.image-name }}.tar
+        run: docker save ${{ inputs.image-name }} > ${{ inputs.image-name }}.tar
 
       - name: Upload Image Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -150,7 +150,7 @@ jobs:
         run: docker load < ${{ inputs.image-name }}.tar
 
       - name: Tag Image
-        run: docker tag $IMAGE_TAG ${{ env.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
+        run: docker tag ${{ inputs.image-name }} ${{ env.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
 
       - name: Configure AWS Creds
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -12,12 +12,28 @@ on:
         required: false
         type: string
         default: '3.13'
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
 
 env:
   ecr-registry: '550487074477.dkr.ecr.us-east-1.amazonaws.com'
   ecr-region: 'us-east-1'
 
 jobs:
+  test-aws-creds:
+    name: Check ACCESS ID
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check AWS Access ID
+        run: echo "${{ secrets.AWS_ACCESS_KEY_ID }}"
+
+      - name: TEST
+        run: echo "echo test after"
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: '3.13'
+      ecr-registry:
+        description: 'ECR registry address'
+        required: true
+        type: string
 
 jobs:
   docker-build:
@@ -23,6 +27,15 @@ jobs:
 
       - name: Build Docker Image
         run: docker build -t ${{ inputs.image-name }}:${{ github.sha }} .
+
+      - name: Save Image
+        run: docker save $IMAGE_TAG > ${{ inputs.image-name }}.tar
+
+      - name: Upload Image Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.image-name }}
+          path: ${{ inputs.image-name }}.tar
 
   tests:
     name: Run Unit Tests
@@ -117,3 +130,37 @@ jobs:
         with:
           name: flake8-report
           path: flake8-report.xml
+
+  publish-ecr:
+    name: Publish to ECR
+    needs: [ docker-build, tests, test-coverage, lint ]
+    runs-on: ubuntu-latest
+#    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Docker Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.image-name }}
+          path: .
+
+      - name: Load Docker Image
+        run: docker load < ${{ inputs.image-name }}.tar
+
+      - name: Tag Image
+        run: docker tag $IMAGE_TAG $ECR_REGISTRY/${{ inputs.image-name }}:${{ github.sha }}
+
+      - name: Configure AWS Creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Push image to ECR
+        run: docker push $ECR_REGISTRY/${{ inputs.image-name }}:${{ github.sha }}

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -150,7 +150,7 @@ jobs:
         run: docker load < ${{ inputs.image-name }}.tar
 
       - name: Tag Image
-        run: docker tag ${{ inputs.image-name }} ${{ env.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
+        run: docker tag ${{ inputs.image-name }}:${{ github.sha }} ${{ env.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
 
       - name: Configure AWS Creds
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -12,10 +12,10 @@ on:
         required: false
         type: string
         default: '3.13'
-      ecr-registry:
-        description: 'ECR registry address'
-        required: true
-        type: string
+
+env:
+  ecr-registry: '550487074477.dkr.ecr.us-east-1.amazonaws.com'
+  ecr-region: 'us-east-1'
 
 jobs:
   docker-build:
@@ -150,17 +150,17 @@ jobs:
         run: docker load < ${{ inputs.image-name }}.tar
 
       - name: Tag Image
-        run: docker tag $IMAGE_TAG ${{ inputs.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
+        run: docker tag $IMAGE_TAG ${{ env.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
 
       - name: Configure AWS Creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ env.ecr-region }}
 
       - name: Login to ECR
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Push image to ECR
-        run: docker push ${{ inputs.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}
+        run: docker push ${{ env.ecr-registry }}/${{ inputs.image-name }}:${{ github.sha }}

--- a/.github/workflows/python-cicd-template.yml
+++ b/.github/workflows/python-cicd-template.yml
@@ -23,17 +23,6 @@ env:
   ecr-region: 'us-east-1'
 
 jobs:
-  test-aws-creds:
-    name: Check ACCESS ID
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check AWS Access ID
-        run: echo "${{ secrets.AWS_ACCESS_KEY_ID }}"
-
-      - name: TEST
-        run: echo "echo test after"
-
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary
- Added a `publish-ecr` stage which requires aws credentials and ecr registry and region details
- Saving an image in the `docker-build` stage so that that image can be loaded in the `publish-ecr` stage and a new one doesn't have to be created
- Added `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets. To be supplied by the service using the template

### Testing
- [x] Successfully published an image to ECR

Closes #7 